### PR TITLE
Fix Crash when using --singularity with Apptainer

### DIFF
--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -58,6 +58,9 @@ def get_version() -> str:
         )
         if _SINGULARITY_VERSION.startswith("singularity version "):
             _SINGULARITY_VERSION = _SINGULARITY_VERSION[20:]
+        if _SINGULARITY_VERSION.startswith("singularity-ce version "):
+            _SINGULARITY_VERSION = _SINGULARITY_VERSION[23:]
+        _logger.debug(f"Singularity version: {_SINGULARITY_VERSION}.")
     return _SINGULARITY_VERSION
 
 

--- a/cwltool/singularity.py
+++ b/cwltool/singularity.py
@@ -60,6 +60,8 @@ def get_version() -> str:
             _SINGULARITY_VERSION = _SINGULARITY_VERSION[20:]
         if _SINGULARITY_VERSION.startswith("singularity-ce version "):
             _SINGULARITY_VERSION = _SINGULARITY_VERSION[23:]
+        if _SINGULARITY_VERSION.startswith("apptainer version "):
+            _SINGULARITY_VERSION = _SINGULARITY_VERSION[18:]
         _logger.debug(f"Singularity version: {_SINGULARITY_VERSION}.")
     return _SINGULARITY_VERSION
 


### PR DESCRIPTION
The problem I was getting:

`Singularity is required to run this tool: invalid literal for int() with base 10: 'a'`

was because on the hive singularity now runs apptainer. This means singularity --version returns:

`apptainer version 1.2.4-1.el9`

which fails to parse in cwltool.

This change fixes that problem and lets the pipeline run. I haven't provided a lookup of which apptainer version is feature compatible with which singularity version, which might be needed in the future if the version logic is used anywhere to enable or disable features.